### PR TITLE
LVN-75: add task priority visualization in TaskItems

### DIFF
--- a/src/components/Dashboard/MainContainer/MainContainer.jsx
+++ b/src/components/Dashboard/MainContainer/MainContainer.jsx
@@ -37,6 +37,7 @@ export default class MainContainer extends Component {
       taskList.push({
         id: task,
         name: snapValue[task].name,
+        priority: snapValue[task].priority,
         description: snapValue[task].description,
         status: snapValue[task].status,
         key: task,

--- a/src/components/Dashboard/TaskItem/TaskItem.jsx
+++ b/src/components/Dashboard/TaskItem/TaskItem.jsx
@@ -11,19 +11,40 @@ export default class TaskItem extends Component {
     };
   }
 
-  closeTaskDetails() {
+  closeTaskDetails = () => {
     this.setState({ modalShow: false });
+  };
+
+  getTaskStyleByPriority = () => {
+    const { priority, status } = this.props;
+    let style = status === 'Done' ? 'taskItemDone' : 'taskItem';
+    switch (priority) {
+      case 'High':
+        style += ' priorityH';
+        break;
+      case 'Medium':
+        style += ' priorityM';
+        break;
+      case 'Low':
+        style += ' priorityL';
+        break;
+      default:
+        break;
+    }
+    return style;
   }
 
   render() {
-    const {
-      taskName, taskListRef, id, status,
-    } = this.props;
+    const { taskName, taskListRef, id } = this.props;
     const taskRef = taskListRef.child(`${id}`);
     const { modalShow: modalOpen } = this.state;
+
     return (
-      <Container className="taskItemContainer">
-        <Container className={status === 'Done' ? 'taskItemDone' : 'taskItem'} onClick={() => this.setState({ modalShow: !modalOpen })}>
+      <Container className="TaskItemContainer">
+        <Container
+          className={this.getTaskStyleByPriority()}
+          onClick={() => this.setState({ modalShow: !modalOpen })}
+        >
           {taskName}
         </Container>
         <Container>

--- a/src/components/Dashboard/TaskItem/TaskItem.scss
+++ b/src/components/Dashboard/TaskItem/TaskItem.scss
@@ -1,5 +1,8 @@
 $task-item-text: rgb(117, 116, 119);
 $task-item-background: linear-gradient(to right, #ececec, #f6f6f6);
+$high-priority: red;
+$medium-priority: orange;
+$low-priority: green;
 
 .taskItem, 
 .taskItemDone {
@@ -21,6 +24,19 @@ $task-item-background: linear-gradient(to right, #ececec, #f6f6f6);
   text-decoration: line-through; 
 }
 
-.taskItemContainer {
+.TaskItemContainer {
   padding: 0;
 }
+
+.priorityH {
+  border-left: 2px solid $high-priority;
+}
+
+.priorityM {
+  border-left: 2px solid $medium-priority;
+}
+
+.priorityL {
+  border-left: 2px solid $low-priority;
+}
+

--- a/src/components/Dashboard/TasksColumn/TasksColumn.jsx
+++ b/src/components/Dashboard/TasksColumn/TasksColumn.jsx
@@ -25,13 +25,16 @@ export default class TasksColumn extends Component {
   }
 
   render() {
-    const { sortedTasks, taskListRef, title } = this.props;
+    const {
+      sortedTasks, taskListRef, title,
+    } = this.props;
 
     const tasksToDisply = sortedTasks.map(
       task => (
         <TaskItem
           key={task.id}
           status={task.status}
+          priority={task.priority}
           id={task.id}
           taskName={task.name}
           taskListRef={taskListRef}


### PR DESCRIPTION
This Pull Request adds task priority visualization in TaskItems. Those are the colorful lines on the left side of the task item based on the task priority: red for `high`, orange for `medium` and green for `low`. They are set accordingly to the task priority from the database and for those tasks that have no priority yet - the style is the same as it was before (with no lines added). 