### PR TITLE
SubTaskList hotfix: taskRef from props was going to state by mistake

### DIFF
--- a/src/components/SubTaskList/SubTaskList.jsx
+++ b/src/components/SubTaskList/SubTaskList.jsx
@@ -10,16 +10,18 @@ import getSubtaskListAsArray from './getSubtaskListAsArray';
 export default class SubTaskList extends Component {
   constructor(props) {
     super(props);
-
+    this.taskRef = props.taskRef;
     this.state = {
-      taskRef: props.taskRef,
       subtaskList: [],
     };
   }
 
   componentDidMount() {
     this.isComponentMounted = true;
-    if (!this.taskRef) return;
+    if (!this.taskRef) {
+      console.log('No taskRef');
+      return;
+    }
     const subtaskListRef = this.taskRef.child('/subtaskList');
     subtaskListRef.on('value', (snapshot) => {
       const subtaskListSnap = snapshot.val() ? snapshot.val() : {};


### PR DESCRIPTION
Important hotfix for changes from my last PR. By mistake, props.taskRef was assigned as a property of a local state, instead of just this.taskRef that is used further in code.